### PR TITLE
bug: Viewing Job Seeker Profile Cleanup

### DIFF
--- a/backend/src/services/profileAccess.js
+++ b/backend/src/services/profileAccess.js
@@ -14,8 +14,7 @@ export function assertCanReadProfile(profile, viewer) {
     const isAdmin = viewer?.role === "admin";
     const isPublic = getProfileVisibility(profile) === "public";
 
-    
     if (!isPublic && !isOwner && !isAdmin) {
-        throw appError("NOT_FOUND", "Profile not found");
+        throw appError("NOT_AUTHORIZED", "This profile is not public");
     }
 }

--- a/frontend/src/components/ApplicantsModal.jsx
+++ b/frontend/src/components/ApplicantsModal.jsx
@@ -1,15 +1,9 @@
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { fetchJobApplicants } from "../lib/jobsApi";
 import { getJobSeekerProfilePath } from "../routing/routes";
 
-function ApplicantRow({ applicant }) {
-  const navigate = useNavigate();
+function ApplicantRow({ applicant, onViewProfile }) {
   const [open, setOpen] = useState(false);
-
-  function onViewProfile(userId) {
-    navigate(getJobSeekerProfilePath(userId));
-  }
 
   return (
     <li className="applicant-row">
@@ -46,10 +40,19 @@ function ApplicantRow({ applicant }) {
   );
 }
 
-function ApplicantsModal({ job, onClose, fetchApplicants }) {
+function ApplicantsModal({ job, onClose, fetchApplicants, getProfilePath }) {
   const [applicants, setApplicants] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
+  const navigate = useNavigate();
+
+  function onViewProfile(userId) {
+    const path = typeof getProfilePath === "function"
+      ? getProfilePath(userId)
+      : getJobSeekerProfilePath(userId);
+
+    navigate(path);
+  }
 
   useEffect(() => {
     let isActive = true;
@@ -107,7 +110,11 @@ function ApplicantsModal({ job, onClose, fetchApplicants }) {
           {!loading && !error && applicants.length > 0 && (
             <ul className="applicants-list">
               {applicants.map((applicant) => (
-                <ApplicantRow key={applicant.id} applicant={applicant} />
+                <ApplicantRow
+                  key={applicant.id}
+                  applicant={applicant}
+                  onViewProfile={onViewProfile}
+                />
               ))}
             </ul>
           )}

--- a/frontend/src/components/JobListPanel.jsx
+++ b/frontend/src/components/JobListPanel.jsx
@@ -192,6 +192,7 @@ function JobListPanel({
   canCreate = true,
   canViewApplicants = false,
   fetchApplicants = null,
+  getApplicantProfilePath = null,
   onTotalCount,
 }) {
   const [formData, setFormData] = useState(INITIAL_FORM);
@@ -601,6 +602,7 @@ function JobListPanel({
           job={viewingApplicantsJob}
           onClose={() => setViewingApplicantsJob(null)}
           fetchApplicants={fetchApplicants}
+          getProfilePath={getApplicantProfilePath}
         />
       )}
     </>

--- a/frontend/src/pages/AdminPage.jsx
+++ b/frontend/src/pages/AdminPage.jsx
@@ -1,7 +1,7 @@
 import { Link } from "react-router-dom";
 import AdminUsersPanel from "../components/admin/AdminUsersPanel";
 import JobListPanel from "../components/JobListPanel";
-import { routePaths, withHash } from "../routing/routes";
+import { routePaths, withHash, getAdminProfilePath } from "../routing/routes";
 import {
   updateAdminJob,
   deleteAdminJob,
@@ -65,6 +65,7 @@ function AdminPage() {
           canCreate={false}
           canViewApplicants={true}
           fetchApplicants={fetchAdminJobApplicants}
+          getApplicantProfilePath={(userId) => getAdminProfilePath("seeker", userId)}
         />
       </section>
     </main>

--- a/frontend/src/profile/ProfileEditorFrame.jsx
+++ b/frontend/src/profile/ProfileEditorFrame.jsx
@@ -36,7 +36,7 @@ function ProfileEditorFrame({
                     {isSaving ? "Saving..." : "Save Changes"}
                   </button>
                 </>
-              ) : (
+              ) : onEdit ? (
                 <button
                   type="button"
                   className="profile-button"
@@ -44,7 +44,7 @@ function ProfileEditorFrame({
                 >
                   {editLabel}
                 </button>
-              )}
+              ) : null}
             </div>
           </div>
           {saveError ? <p className="profile-status profile-status-error">{saveError}</p> : null}


### PR DESCRIPTION
Fixes a bug where viewing a job seeker profile from the list of applicants on a job posting only worked for employers and not admins.

Also removed the "Edit Profile" button when viewing a job seeker profile. (It didn't work to edit another user's account before anyways, this just removes the button from the page)